### PR TITLE
Refactor CSS styling to scope SVG patterns and separate concerns

### DIFF
--- a/.mdbook/bookstyle.css
+++ b/.mdbook/bookstyle.css
@@ -1,0 +1,50 @@
+img+em {
+    display: block;
+}
+
+crossreference {
+    background-color: var(--quote-bg);
+    border: 3px solid var(--quote-border);
+    display: block;
+    padding: 8px;
+}
+
+.video {
+    display: none;
+}
+
+todo-sync-group {
+    display: block;
+    white-space: pre;
+    background-color: red;
+}
+
+TODO-manipulator-sync {
+    display: block;
+    white-space: pre;
+    background-color: red;
+}
+
+todo-sync-group:before {
+    content: "TODO: ";
+}
+
+todo-siteswap-group {
+    display: block;
+    white-space: pre;
+    background-color: red;
+}
+
+todo-siteswap-group:before {
+    content: "TODO: ";
+}
+
+.global-toc #modern-passing-1 {
+    display: none;
+}
+.global-toc p {
+    display: none;
+}
+.global-toc h1 {
+    font-size: 1.6rem;
+}

--- a/.mdbook/svgstyle.css
+++ b/.mdbook/svgstyle.css
@@ -1,86 +1,21 @@
-.starting-hands {
-    fill: var(--fg)
+.passingpattern {
+    --bg-color: #fff;
+    --bg-secondary-color: #f3f3f6;
+    --tab-inactive: #d2d6dd;
+    --tab-hover: #747681;
+    --tab-active: #3f4144;
 }
 
-.throw-label {
-    fill: var(--fg)
-}
+svg.passingpattern { max-width: 100%; }
 
-img+em {
-    display: block
-}
+.passingpattern .starting-hands { fill: var(--fg, #000); }
+.passingpattern .throw-label { fill: var(--fg, #000); }
 
-crossreference {
-    background-color: var(--quote-bg);
-    border: 3px solid var(--quote-border);
-    display: block;
-    padding: 8px;
-}
-
-.video {
-    display: none;
-}
-
- 
-
-svg { max-width: 100%;}
-
-
-todo-sync-group {
-    display: block;
-    white-space: pre;
-    background-color: red;
-}
-
-TODO-manipulator-sync {
-    display: block;
-    white-space: pre;
-    background-color: red;
-}
-
-todo-sync-group:before {
-    content: "TODO: "
-}
-
-todo-siteswap-group {
-    display: block;
-    white-space: pre;
-    background-color: red;
-}
-
-todo-siteswap-group:before {
-    content: "TODO: "
-}
-
-        
-svg .tab { cursor: pointer; }
-svg .tab rect { fill: var(--bg-color); stroke: var(--tab-inactive); }
-svg .tab text { fill: #666; font-size: 8px;      text-anchor: middle;            dominant-baseline: central;}
-svg .tab line {  stroke: transparent;           stroke-width: 3; }
-svg .tab:hover rect { fill: var(--bg-secondary-color); }
-svg .tab-active rect { fill: white; stroke: var(--tab-active); stroke-width: 2; }
-svg .tab-active text { fill: var(--tab-active); font-weight: 600;      text-anchor: middle; dominant-baseline: central;}
-svg .tab-active line { stroke: var(--tab-active);            stroke-width: 3;}
-/* svg { border: 1px solid #e5e5e5; } */
-
-:root {
-    --bg-color:#fff;
-    --bg-secondary-color:#f3f3f6;
-    --tab-inactive:#d2d6dd;
-    --tab-hover:#747681;
-    --tab-active:#3f4144;
-  }
-
-
-
-
-.global-toc #modern-passing-1 {
-    display: none;
-}
-.global-toc p {
-    display: none;
-}
-.global-toc h1 {
-      font-size: 1.6rem;
-}
-
+.passingpattern .tab { cursor: pointer; }
+.passingpattern .tab rect { fill: var(--bg-color); stroke: var(--tab-inactive); }
+.passingpattern .tab text { fill: #666; font-size: 8px; text-anchor: middle; dominant-baseline: central; }
+.passingpattern .tab line { stroke: transparent; stroke-width: 3; }
+.passingpattern .tab:hover rect { fill: var(--bg-secondary-color); }
+.passingpattern .tab-active rect { fill: white; stroke: var(--tab-active); stroke-width: 2; }
+.passingpattern .tab-active text { fill: var(--tab-active); font-weight: 600; text-anchor: middle; dominant-baseline: central; }
+.passingpattern .tab-active line { stroke: var(--tab-active); stroke-width: 3; }

--- a/book.toml
+++ b/book.toml
@@ -16,7 +16,7 @@ command = "deno run -A vizsiteswap/mdbook-siteswapsvg.ts"
 #command = "compatsiteswaps/mdbook-compatsiteswaps"
 
 [output.html]
-additional-css = [".mdbook/svgstyle.css"]
+additional-css = [".mdbook/svgstyle.css", ".mdbook/bookstyle.css"]
 additional-js = ["vizsiteswap/dist/animations.js","vizsiteswap/dist/svg.min.js"]
 smart-punctuation = true
 git-repository-url = "https://github.com/ckaestne/modernpassing"

--- a/takeout-explorer/src/main.tsx
+++ b/takeout-explorer/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import App from "./App.tsx"
 import "./index.css"
+import "../../.mdbook/svgstyle.css"
 
 createRoot(document.getElementById("root")!).render(
     <StrictMode>

--- a/vizsiteswap/rendering-svg/debug-server.ts
+++ b/vizsiteswap/rendering-svg/debug-server.ts
@@ -21,6 +21,7 @@ function page(p: string, svg1: string,svg2: string,svg3: string, isValid: boolea
                     <meta name="viewport" content="width=device-width, initial-scale=1.0">
                     <script src="https://cdn.jsdelivr.net/npm/@svgdotjs/svg.js@3.2.4/dist/svg.min.js"></script>
                     <script src="/animations.js"></script>
+                    <link rel="stylesheet" href="/svgstyle.css">
                     <style>
                         body {
                             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
@@ -167,6 +168,19 @@ app.use(async (ctx, next) => {
             const text = await Deno.readTextFile("dist/animations.js");
             ctx.response.body = text;
             ctx.response.type = "application/javascript";
+        } catch (e) {
+            ctx.response.status = 404;
+            ctx.response.body = "File not found";
+        }
+        return;
+    }
+
+    if (ctx.request.url.pathname === "/svgstyle.css") {
+        try {
+            const cssUrl = new URL("../../.mdbook/svgstyle.css", import.meta.url);
+            const text = await Deno.readTextFile(cssUrl);
+            ctx.response.body = text;
+            ctx.response.type = "text/css";
         } catch (e) {
             ctx.response.status = 404;
             ctx.response.body = "File not found";

--- a/vizsiteswap/rendering-svg/renderer-svg.ts
+++ b/vizsiteswap/rendering-svg/renderer-svg.ts
@@ -56,7 +56,7 @@ export function renderGroupPattern(gp: GroupPattern, config: Partial<RendererCon
     const layoutGap = 10
     const width = onlyLayout ? layoutSize : size.width + layoutSize + layoutGap
     const height = onlyLayout ? layoutSize : Math.max(size.height + tabHeight + turntableHeight, layoutSize)
-    const svg = createSVG(width, height).viewbox(0, 0, width, height)
+    const svg = createSVG(width, height).viewbox(0, 0, width, height).addClass("passingpattern")
 
     const [panels, tabData] = createTabs(svg, tabTitles)
 
@@ -440,7 +440,7 @@ export function renderPlainPattern(p: Pattern, config?: Partial<RendererConfig>)
     const renderConfig: RendererConfig = { ...customRendererConfigDefaults(p), ...config }
 
     const size = getRenderPatternSize(p, renderConfig)
-    const svg = createSVG(size.width, size.height).viewbox(0, 0, size.width, size.height)
+    const svg = createSVG(size.width, size.height).viewbox(0, 0, size.width, size.height).addClass("passingpattern")
     const patternCanvas = svg.group()
     renderInternal(patternCanvas, p, p.getInitialRoles(), getThrowsFromPattern(p, renderConfig.iterations, renderConfig), getRelabel(p), renderConfig)
 


### PR DESCRIPTION
## Summary
This PR refactors the CSS styling architecture by scoping SVG pattern styles to a `.passingpattern` class and separating book-specific styles into a dedicated stylesheet. This improves style encapsulation and makes the codebase more maintainable.

## Key Changes
- **Scoped SVG styles**: All SVG-related styles in `svgstyle.css` are now scoped under `.passingpattern` class selector, preventing unintended style leakage
- **Separated concerns**: Extracted book-specific styles (custom elements, TODOs, global TOC) into new `bookstyle.css` file
- **Updated SVG rendering**: Added `.passingpattern` class to all generated SVG elements in `renderer-svg.ts`
- **Enhanced debug server**: Added CSS file serving endpoint in debug server to support local development
- **Updated configuration**: Modified `book.toml` to include both stylesheets in the build output
- **Improved fallbacks**: Added fallback color values (`#000`) to SVG text fill properties for better robustness
- **Extended React app**: Imported `svgstyle.css` in the takeout explorer React application

## Implementation Details
- The refactoring maintains all existing styling behavior while improving specificity and preventing style conflicts
- CSS variables are now scoped to `.passingpattern` class, making them more predictable and easier to override
- The debug server now properly serves the CSS file with correct MIME type for local testing
- Both stylesheets are loaded in the mdbook build, ensuring consistent styling across the documentation

https://claude.ai/code/session_01RTVKsJJXCf5eYrqpZQkxkY